### PR TITLE
Fix Search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -36,7 +36,7 @@ class SearchController < ApplicationController
 
 
             if(!users.empty?)
-                filtered_user_ids = users.uniq.pluck("users.id")
+                filtered_user_ids = users.distinct.pluck("users.id")
 
                 if(!params[:day].empty? || !params[:start_hour].empty?) #Schedule based search
                     time_block = { }


### PR DESCRIPTION
Hello! I noticed search wasn't working for me on the site (names worked, but trying to filter by day/hour/etc did not) and thought this would be a fun and valuable open source contribution, so I hope this helps.

I was logging variables in the search controller and got:
`Filtered user IDs: [nil, nil, nil, nil, nil]`

Conferring with AI, it appeared that `uniq` was the issue, and has evidently been deprecated in favor of `distinct`. Once `distinct` was applied, the `Filtered user IDs` became an array of `user_ids` again.

This *appears* to fix the issue locally, although I am a complete Ruby noob so I have no idea really.
Feel free to test it yourself!

If you'd like, I can make a test for the searchcontroller, but will need to find some time to do that.