### PR TITLE
Fix password autocomplete blocking Update Profile

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -149,14 +149,14 @@
               <div>
                 <%= f.label :password, "New Password", class: "block text-sm font-medium text-gray-700 mb-2" %>
                 <div class="w-full">
-                  <%= f.password_field :password, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500 sm:text-sm", placeholder: "Leave blank to keep current password" %>
+                  <%= f.password_field :password, autocomplete: "new-password", class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500 sm:text-sm", placeholder: "Leave blank to keep current password" %>
                 </div>
               </div>
 
               <div>
                 <%= f.label :password_confirmation, "Confirm New Password", class: "block text-sm font-medium text-gray-700 mb-2" %>
                 <div class="w-full">
-                  <%= f.password_field :password_confirmation, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500 sm:text-sm" %>
+                  <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500 sm:text-sm" %>
                 </div>
               </div>
 


### PR DESCRIPTION
Browsers may automatically populate your saved password to the New Password field on the user edit page, which allows for the Update Profile action, but causes it to actually fail to update, and does not indicate why with any error message.

As it was, you had to remove your password from the input every time.

Since new password doesn't need to inherit your current password, I've added the autocomplete attribute set to "new-password" instead. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/password#new-password

#### Before
<img width="696" height="299" alt="Screenshot 2026-06-20 at 3 47 28 AM" src="https://github.com/user-attachments/assets/e85ec0d8-a2bb-43f0-a6ed-5f0ef5c29bb3" />


#### After
<img width="695" height="295" alt="Screenshot 2026-06-20 at 3 46 59 AM" src="https://github.com/user-attachments/assets/6477d5b1-475a-40ab-a182-3abb96b31a85" />
